### PR TITLE
Talon config

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -145,7 +145,8 @@ public class Robot extends TimedRobot {
         SmartDashboard.putNumber("Outer Port Yaw", VisionCtrlNetTable.yawToOuterPort.get());
         SmartDashboard.putNumber("PowerCell Distance", VisionCtrlNetTable.distanceToPowerCell.get());
         SmartDashboard.putNumber("Pigeon Yaw", DriveBaseHolder.getInstance().getCurrentAngle());
-        SmartDashboard.putBoolean("Limit Switch", !ShooterSubsystem.getInstance().shooterDigitalInput.get());
+        if (Config.SHOOTER_MOTOR != -1)
+            SmartDashboard.putBoolean("Limit Switch", !ShooterSubsystem.getInstance().shooterDigitalInput.get());
 
         CommandScheduler.getInstance().run();
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -68,7 +68,9 @@ public class RobotContainer {
             analogSelectorOne = new AnalogSelector(Config.ANALOG_SELECTOR_ONE);
         }
 
-        ArmSubsystem armSubsystem = ArmSubsystem.getInstance();
+        ArmSubsystem armSubsystem;
+        if (Config.ARM_TALON != -1)
+            armSubsystem = ArmSubsystem.getInstance();
 
         configureButtonBindings();
     }

--- a/src/main/java/frc/robot/config/Config.java
+++ b/src/main/java/frc/robot/config/Config.java
@@ -74,25 +74,25 @@ public class Config {
     // Static Constants
     private static Class<? extends DriveBase> Pre2020DriveBase = DriveBasePre2020.class.asSubclass(DriveBase.class);
     private static Class<? extends DriveBase> Post2020DriveBase = DriveBase2020.class.asSubclass(DriveBase.class);
-    public static Class<? extends DriveBase> DRIVEBASE_CLASS = robotSpecific(Post2020DriveBase, Post2020DriveBase, Pre2020DriveBase, Pre2020DriveBase, Pre2020DriveBase, Pre2020DriveBase, Pre2020DriveBase, Pre2020DriveBase, Pre2020DriveBase);
+    public static Class<? extends DriveBase> DRIVEBASE_CLASS = robotSpecific(Post2020DriveBase, Post2020DriveBase, Pre2020DriveBase, Post2020DriveBase, Pre2020DriveBase, Pre2020DriveBase, Pre2020DriveBase, Pre2020DriveBase, Pre2020DriveBase);
     public static int RIGHT_FRONT_MOTOR = robotSpecific(2, 2, 3, 2, 2);
     public static int RIGHT_REAR_MOTOR = robotSpecific(4, 4, 4, 4, 4);
     public static int LEFT_FRONT_MOTOR = robotSpecific(1, 1, 1, 1, 1);
     public static int LEFT_REAR_MOTOR = robotSpecific(3, 3, 2, 3, 3);
-    public static int INTAKE_MOTOR = robotSpecific(6, 6, -1, 6, -1);
+    public static int INTAKE_MOTOR = robotSpecific(6, 6, -1, -1, -1);
     public static int SHOOTER_MOTOR = robotSpecific(5, 5, -1, -1, 16); //protobot is 16
     public static int CLIMBER_TALON = robotSpecific(10, 10, -1, -1, 16);
-    public static int AGITATOR_MOTOR = robotSpecific(9, 9);
+    public static int AGITATOR_MOTOR = robotSpecific(9, 9, -1, -1);
 
     public static boolean LEFT_SLAVE_ISVICTOR = robotSpecific(true, true, true, false);
     public static boolean RIGHT_SLAVE_ISVICTOR = robotSpecific(true, true, true, false);
     
-    public static boolean LEFT_FRONT_INVERTED = robotSpecific(false, false, false, true);
-    public static boolean RIGHT_FRONT_INVERTED = robotSpecific(false, false, false, true);
-    public static boolean LEFT_REAR_INVERTED = robotSpecific(false, false, false, true);
-    public static boolean RIGHT_REAR_INVERTED = robotSpecific(false, false, false, true);
+    public static boolean LEFT_FRONT_INVERTED = robotSpecific(false, false, false, false);
+    public static boolean RIGHT_FRONT_INVERTED = robotSpecific(false, false, false, false);
+    public static boolean LEFT_REAR_INVERTED = robotSpecific(false, false, false, false);
+    public static boolean RIGHT_REAR_INVERTED = robotSpecific(false, false, false, false);
     public static boolean DRIVETRAIN_LEFT_SENSORPHASE = robotSpecific(false, false, false, true);
-    public static boolean DRIVETRAIN_RIGHT_SENSORPHASE = robotSpecific(false, false, false, true);
+    public static boolean DRIVETRAIN_RIGHT_SENSORPHASE = robotSpecific(false, false, false, false);
 
     // Current limiter Constants
     public static int PEAK_CURRENT_AMPS = 80;           //Peak current threshold to trigger the current limit
@@ -101,13 +101,13 @@ public class Config {
     public static boolean MOTOR_CURRENT_LIMIT = true;   //Enable or disable motor current limiting.
 
     public static int TALON_5_PLYBOY = robotSpecific(-1, -1, -1, -1, -1, 5);
-    public static int PIGEON_ID = robotSpecific(CLIMBER_TALON, CLIMBER_TALON, RIGHT_REAR_MOTOR, LEFT_FRONT_MOTOR, LEFT_REAR_MOTOR, TALON_5_PLYBOY);
+    public static int PIGEON_ID = robotSpecific(CLIMBER_TALON, CLIMBER_TALON, RIGHT_REAR_MOTOR, LEFT_REAR_MOTOR, LEFT_REAR_MOTOR, TALON_5_PLYBOY);
     
     public static int ANALOG_SELECTOR_ONE = robotSpecific(0, 0, -1, -1, -1, 0);
     
-    public static int ARM_TALON = robotSpecific(7, 7, 12);
+    public static int ARM_TALON = robotSpecific(7, 7, 12, -1);
 
-    public static int FEEDER_SUBSYSTEM_TALON = robotSpecific(8, 8);
+    public static int FEEDER_SUBSYSTEM_TALON = robotSpecific(8, 8, -1, -1);
     
     public static Double DRIVE_OPEN_LOOP_DEADBAND = 0.04;
     

--- a/src/main/java/frc/robot/config/Config.java
+++ b/src/main/java/frc/robot/config/Config.java
@@ -83,6 +83,8 @@ public class Config {
     public static int SHOOTER_MOTOR = robotSpecific(5, 5, -1, -1, 16); //protobot is 16
     public static int CLIMBER_TALON = robotSpecific(10, 10, -1, -1, 16);
     public static int AGITATOR_MOTOR = robotSpecific(9, 9);
+    public static boolean LEFT_SLAVE_ISVICTOR = robotSpecific(true, true, true, false);
+    public static boolean RIGHT_SLAVE_ISVICTOR = robotSpecific(true, true, true, false);
 
     // Current limiter Constants
     public static int PEAK_CURRENT_AMPS = 80;           //Peak current threshold to trigger the current limit

--- a/src/main/java/frc/robot/config/Config.java
+++ b/src/main/java/frc/robot/config/Config.java
@@ -83,8 +83,16 @@ public class Config {
     public static int SHOOTER_MOTOR = robotSpecific(5, 5, -1, -1, 16); //protobot is 16
     public static int CLIMBER_TALON = robotSpecific(10, 10, -1, -1, 16);
     public static int AGITATOR_MOTOR = robotSpecific(9, 9);
+
     public static boolean LEFT_SLAVE_ISVICTOR = robotSpecific(true, true, true, false);
     public static boolean RIGHT_SLAVE_ISVICTOR = robotSpecific(true, true, true, false);
+    
+    public static boolean LEFT_FRONT_INVERTED = robotSpecific(false, false, false, true);
+    public static boolean RIGHT_FRONT_INVERTED = robotSpecific(false, false, false, true);
+    public static boolean LEFT_REAR_INVERTED = robotSpecific(false, false, false, true);
+    public static boolean RIGHT_REAR_INVERTED = robotSpecific(false, false, false, true);
+    public static boolean DRIVETRAIN_LEFT_SENSORPHASE = robotSpecific(false, false, false, true);
+    public static boolean DRIVETRAIN_RIGHT_SENSORPHASE = robotSpecific(false, false, false, true);
 
     // Current limiter Constants
     public static int PEAK_CURRENT_AMPS = 80;           //Peak current threshold to trigger the current limit

--- a/src/main/java/frc/robot/subsystems/AgitatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/AgitatorSubsystem.java
@@ -15,21 +15,25 @@ public class AgitatorSubsystem extends SubsystemBase {
 
     private AgitatorSubsystem() {
         //Defining the agitator motor
-        agitatorMotor = new VictorSPX(Config.AGITATOR_MOTOR);
+        if (Config.AGITATOR_MOTOR != -1)
+            agitatorMotor = new VictorSPX(Config.AGITATOR_MOTOR);
     }
 
     public void runAgitator() {
         // Runs the agitator at full speed
-        agitatorMotor.set(ControlMode.PercentOutput, AGITATOR_SPEED);
+        if (Config.AGITATOR_MOTOR != -1)
+            agitatorMotor.set(ControlMode.PercentOutput, AGITATOR_SPEED);
     }
 
     public void stopAgitator() {
         // Stops the agitator
-        agitatorMotor.set(ControlMode.PercentOutput, 0.0);
+        if (Config.AGITATOR_MOTOR != -1)
+            agitatorMotor.set(ControlMode.PercentOutput, 0.0);
     }
 
     public void reverseAgitator() {
         //Runs the agitator in reverse
-        agitatorMotor.set(ControlMode.PercentOutput, -AGITATOR_SPEED);
+        if (Config.AGITATOR_MOTOR != -1)
+            agitatorMotor.set(ControlMode.PercentOutput, -AGITATOR_SPEED);
     }
 }

--- a/src/main/java/frc/robot/subsystems/ArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ArmSubsystem.java
@@ -108,13 +108,15 @@ public class ArmSubsystem extends ConditionalSubsystemBase {
         }
     }
 
-
     /**
-     * Return the singleton arm instance
+     * Return the singleton arm instance. Instantiates instance if not already done so.
      *
      * @return the Arm instance
      */
     public static ArmSubsystem getInstance() {
+        if (INSTANCE == null)
+            INSTANCE = new ArmSubsystem();
+        
         return INSTANCE;
     }
 
@@ -144,16 +146,18 @@ public class ArmSubsystem extends ConditionalSubsystemBase {
 
         SmartDashboard.putNumber("Lower Limit", REVERSE_LIMIT_TICKS);
         SmartDashboard.putNumber("Upper Limit", FORWARD_LIMIT_TICKS);
-        SmartDashboard.putNumber("Arm Motor Ticks", armTalon.getSelectedSensorPosition());
+        if (Config.ARM_TALON != -1)
+            SmartDashboard.putNumber("Arm Motor Ticks", armTalon.getSelectedSensorPosition());
         //GABBY commented out
         //SmartDashboard.putNumber("Arm Angle", toDeg(armTalon.getSelectedSensorPosition()));
         SmartDashboard.putNumber("Desired Position", currentPosition);
 
 
         armTalon.set(ControlMode.Position, currentPosition);
-
-        if(armTalon.getSelectedSensorPosition() <= REVERSE_LIMIT_TICKS + 25) {
-            armTalon.set(0.0);
+        if (Config.ARM_TALON != 1) {
+            if(armTalon.getSelectedSensorPosition() <= REVERSE_LIMIT_TICKS + 25) {
+                armTalon.set(0.0);
+            }
         }
     }
 
@@ -162,7 +166,7 @@ public class ArmSubsystem extends ConditionalSubsystemBase {
     }
 
     public boolean reachedPosition(int position) {
-        return Math.abs(armTalon.getSelectedSensorPosition() - position) < acceptableError;
+        return Math.abs(armTalon.getSelectedSensorPosition() - position) < acceptableError; 
     }
 
     /**

--- a/src/main/java/frc/robot/subsystems/DriveBase2020.java
+++ b/src/main/java/frc/robot/subsystems/DriveBase2020.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 
 public class DriveBase2020 extends DriveBase {
     WPI_TalonSRX leftMaster, rightMaster, climberTalon;
-    WPI_VictorSPX leftSlave, rightSlave;
+    BaseMotorController leftSlave, rightSlave;
 
     // DriveBase2020 is a singleton class as it represents a physical subsystem
     private static DriveBase2020 currentInstance;
@@ -34,8 +34,20 @@ public class DriveBase2020 extends DriveBase {
     public DriveBase2020() {
         leftMaster = new WPI_TalonSRX(Config.LEFT_FRONT_MOTOR);
         rightMaster = new WPI_TalonSRX(Config.RIGHT_FRONT_MOTOR);
-        leftSlave = new WPI_VictorSPX(Config.LEFT_REAR_MOTOR);
-        rightSlave = new WPI_VictorSPX(Config.RIGHT_REAR_MOTOR);
+
+        // Check whether to construct a victor or a talon
+        if (Config.LEFT_SLAVE_ISVICTOR) {
+            leftSlave = new WPI_VictorSPX(Config.LEFT_REAR_MOTOR);
+        } else {
+            leftSlave = new WPI_TalonSRX(Config.LEFT_REAR_MOTOR);
+        }
+        if (Config.RIGHT_SLAVE_ISVICTOR) {
+            rightSlave = new WPI_VictorSPX(Config.RIGHT_REAR_MOTOR);
+        } else {
+            rightSlave = new WPI_TalonSRX(Config.RIGHT_REAR_MOTOR);
+        }
+
+
         climberTalon = new WPI_TalonSRX(Config.CLIMBER_TALON);
         differentialDrive = new DifferentialDrive(leftMaster, rightMaster);
 
@@ -109,9 +121,10 @@ public class DriveBase2020 extends DriveBase {
     @Override
     public void stopMotors() {
         leftMaster.stopMotor();
-        leftSlave.stopMotor();
         rightMaster.stopMotor();
-        rightSlave.stopMotor();
+
+        leftSlave.neutralOutput();
+        rightSlave.neutralOutput();
     }
     
     @Override

--- a/src/main/java/frc/robot/subsystems/DriveBase2020.java
+++ b/src/main/java/frc/robot/subsystems/DriveBase2020.java
@@ -5,6 +5,7 @@ import com.ctre.phoenix.motorcontrol.FeedbackDevice;
 import com.ctre.phoenix.motorcontrol.IMotorController;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.BaseMotorController;
+import com.ctre.phoenix.motorcontrol.can.TalonSRXConfiguration;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 import com.ctre.phoenix.motorcontrol.can.WPI_VictorSPX;
 import com.ctre.phoenix.motorcontrol.SupplyCurrentLimitConfiguration;
@@ -37,6 +38,9 @@ public class DriveBase2020 extends DriveBase {
         rightSlave = new WPI_VictorSPX(Config.RIGHT_REAR_MOTOR);
         climberTalon = new WPI_TalonSRX(Config.CLIMBER_TALON);
         differentialDrive = new DifferentialDrive(leftMaster, rightMaster);
+
+        resetMotors();
+        setTalonConfigurations();
 
         //Current limiting for drivetrain master motors.
         if (Config.MOTOR_CURRENT_LIMIT == true) {
@@ -126,6 +130,15 @@ public class DriveBase2020 extends DriveBase {
 
 
         this.followMotors();
+    }
+
+    private void setTalonConfigurations() {
+        TalonSRXConfiguration talonConfig = new TalonSRXConfiguration(); 
+        talonConfig.neutralDeadband = Config.DRIVE_OPEN_LOOP_DEADBAND;
+        
+
+        ErrorCode e1 = leftMaster.configAllSettings(talonConfig);
+        ErrorCode e2 = rightMaster.configAllSettings(talonConfig);
     }
 
     public void setCoastMode() {

--- a/src/main/java/frc/robot/subsystems/FeederSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/FeederSubsystem.java
@@ -168,10 +168,11 @@ public class FeederSubsystem extends ConditionalSubsystemBase {
     }
 
     public void periodic() {
-        SmartDashboard.putNumber("Feeder encoder ticks", feederTalon.getSelectedSensorPosition());
-        SmartDashboard.putNumber("Feeder RPM", (feederTalon.getSelectedSensorPosition() * 600.0) / 4096);
+        if (Config.FEEDER_SUBSYSTEM_TALON != -1) {
+            SmartDashboard.putNumber("Feeder encoder ticks", feederTalon.getSelectedSensorPosition());
+            SmartDashboard.putNumber("Feeder RPM", (feederTalon.getSelectedSensorPosition() * 600.0) / 4096);
+        }
     }
-
     public void stopFeeder() {
         feederTalon.stopMotor();
     }

--- a/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
@@ -32,10 +32,9 @@ public class IntakeSubsystem extends ConditionalSubsystemBase {
         createCondition("dummyPlaceholder", SubsystemConditionStates.AUTO).setState(false);
         if (Config.INTAKE_MOTOR != -1) {
             intakeMotor = new TalonSRX(Config.INTAKE_MOTOR);
+            intakeMotor.setInverted(true);
         }
-
-        intakeMotor.setInverted(true);
-
+        
     }
 
     /**


### PR DESCRIPTION
Mostly changed the way talon configurations are set in the drivebase. Instead of resetting to factory defaults every time we disable, only do it when the drivebase2020 is constructed. Also left room for more settings to be added.
Changed the way follower motors are constructed in the drivebase2020 so that the config can tell it whether to construct a talon or a victor. Erik/Brian robot has talons for the follower motors and most other drivetrains are victors.

Added basic error checking/logging for drivebase talons.

Changed a few config values only on robot id 3 which is the id of Erik/Brian robot. 
Also put some if statements so that is the config says a talon has an id of -1 (robotSpecifc saying that robot doesn't have any talons for that specific subsystem) then don't make calls to hardware that doesn't exist.