### PR TITLE
Fixed the double instance of DriveBase2020

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -151,8 +151,8 @@ public class Robot extends TimedRobot {
         CommandScheduler.getInstance().run();
 
         //The following 2 lines run Drivebase methods that tell shuffleboard what the motor current draw is and if motor current limiting is active.
-        DriveBase2020.getInstance().getMotorCurrent();
-        DriveBase2020.getInstance().isMotorLimitActive();
+        DriveBaseHolder.getInstance().getMotorCurrent();
+        DriveBaseHolder.getInstance().isMotorLimitActive();
     }
 
     /**

--- a/src/main/java/frc/robot/commands/DriveWithTime.java
+++ b/src/main/java/frc/robot/commands/DriveWithTime.java
@@ -64,7 +64,7 @@ public class DriveWithTime extends CommandBase {
   @Override
   public void end(boolean interrupted) {
     // If using the withTimeout(double seconds); as the timer, return here.
-    DriveBase2020.getInstance().stopMotors();
+    DriveBaseHolder.getInstance().stopMotors();
   }
 
 

--- a/src/main/java/frc/robot/subsystems/DriveBase.java
+++ b/src/main/java/frc/robot/subsystems/DriveBase.java
@@ -163,4 +163,10 @@ public abstract class DriveBase extends SubsystemBase {
     protected void neutralModeUpdated(NeutralMode neutralMode) {
     
     }
+
+    public abstract double getMotorCurrent();
+
+    public abstract boolean isMotorLimitActive();
+
+    
 }

--- a/src/main/java/frc/robot/subsystems/DriveBase2020.java
+++ b/src/main/java/frc/robot/subsystems/DriveBase2020.java
@@ -20,9 +20,6 @@ public class DriveBase2020 extends DriveBase {
     WPI_TalonSRX leftMaster, rightMaster, climberTalon;
     BaseMotorController leftSlave, rightSlave;
 
-    // DriveBase2020 is a singleton class as it represents a physical subsystem
-    private static DriveBase2020 currentInstance;
-
     public double motorCurrent; //variable to display motor current levels
     public boolean motorLimitActive = false; //states if motor current is actively being limited
     
@@ -68,6 +65,7 @@ public class DriveBase2020 extends DriveBase {
 
     }
 
+    @Override
     public double getMotorCurrent() {
         //Get motor supply current, send it to shuffleboard, and return it.
         motorCurrent = (leftMaster.getSupplyCurrent() + rightMaster.getSupplyCurrent())/2;
@@ -75,6 +73,7 @@ public class DriveBase2020 extends DriveBase {
         return(motorCurrent); //Returns average motor current draw.
     }
 
+    @Override
     public boolean isMotorLimitActive() {
         //Checks if motor currents are at or above the continuous limit (checks if current limiting is imminent or ongoing)
         //This method does not limit motor current. It monitors current for driver feedback purposes.
@@ -90,20 +89,6 @@ public class DriveBase2020 extends DriveBase {
         return(motorLimitActive);
     }
 
-    /**
-     * Initialize the current DriveBase instance
-     */
-    public static void init() {
-        if (currentInstance == null) {
-            currentInstance = new DriveBase2020();
-        }
-    }
-
-    public static DriveBase2020 getInstance() {
-        init();
-        return currentInstance;
-    }
-    
     @Override
     public void stopMotors() {
         leftMaster.stopMotor();

--- a/src/main/java/frc/robot/subsystems/DriveBasePre2020.java
+++ b/src/main/java/frc/robot/subsystems/DriveBasePre2020.java
@@ -110,4 +110,16 @@ public class DriveBasePre2020 extends DriveBase {
         leftRearTalon.follow(leftFrontTalon);
         rightRearTalon.follow(rightFrontTalon);
     }
+
+    @Override
+    public double getMotorCurrent() {
+        return 0.0d;
+    }
+
+    @Override
+    public boolean isMotorLimitActive() {
+        return false;
+    }
+
+
 }


### PR DESCRIPTION
DriveBaseHolder creates an instance of the DriveBase2020 but the drivebase2020 also has a getInstance() method which creates a second instance of the drivebase2020.

This resulted in 2 differentialDrive objects with one which received joystick inputs and which didn't. THe talons would receive both inputs of 0 and what the joysticks wanted. Resulting in talons freaking out.

Removed the getInstance method in drivebase2020.