### PR TITLE
Arm code

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -140,11 +140,14 @@ public class RobotContainer {
         new JoystickButton(driverStick, XboxController.Button.kA.value).whenHeld(moveToOuterPort, true);
 
         if (Config.ARM_TALON != -1) {
-            reverseArmManually = new MoveArmManuallyCommand(-0.35);
+            reverseArmManually = new InstantCommand(() -> ArmSubsystem.getInstance().setPosition(0));  //new MoveArmManuallyCommand(-0.35);
             new JoystickButton(driverStick, XboxController.Button.kX.value).whenHeld(reverseArmManually);
 
-            moveArm = new MoveArmManuallyCommand(10);
+            moveArm = new InstantCommand(() -> ArmSubsystem.getInstance().setPosition(300)); // new MoveArmManuallyCommand(10);
             new JoystickButton(driverStick, XboxController.Button.kY.value).whenHeld(moveArm);
+
+            Command upperArmPos = new InstantCommand(() -> ArmSubsystem.getInstance().setPosition(600));
+            new JoystickButton(driverStick, XboxController.Button.kB.value).whenHeld(upperArmPos);
         }
 
         sensitiveDriving = new SensitiveDriverControl(driverStick);
@@ -365,7 +368,7 @@ public class RobotContainer {
             case 0:
                 return null;
 
-            case 1:{
+            case 1: {
                 /** Bounce path  */
                 Trajectory trajectory1 = TrajectoryGenerator.generateTrajectory(List.of(
                     new PoseScaled(0.9, -2.4, 0),

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -141,18 +141,18 @@ public class RobotContainer {
         positionPowercell = new PositionPowercellCommand();
         new JoystickButton(controlStick, XboxController.Button.kBumperRight.value).toggleWhenActive(positionPowercell, true);
 
-        moveToOuterPort = new TurnToOuterPortCommand(true, 3.0, 2.0);
-        new JoystickButton(driverStick, XboxController.Button.kA.value).whenHeld(moveToOuterPort, true);
-
         if (Config.ARM_TALON != -1) {
-            reverseArmManually = new InstantCommand(() -> ArmSubsystem.getInstance().setPosition(0));  //new MoveArmManuallyCommand(-0.35);
-            new JoystickButton(driverStick, XboxController.Button.kX.value).whenHeld(reverseArmManually);
+            InstantCommand armSetpoint0 = new InstantCommand(() -> ArmSubsystem.getInstance().setpoint(0));  //new MoveArmManuallyCommand(-0.35);
+            new JoystickButton(driverStick, XboxController.Button.kX.value).whenHeld(armSetpoint0);
 
-            moveArm = new InstantCommand(() -> ArmSubsystem.getInstance().setPosition(300)); // new MoveArmManuallyCommand(10);
-            new JoystickButton(driverStick, XboxController.Button.kY.value).whenHeld(moveArm);
+            InstantCommand armSetpoint1 = new InstantCommand(() -> ArmSubsystem.getInstance().setpoint(1)); // new MoveArmManuallyCommand(10);
+            new JoystickButton(driverStick, XboxController.Button.kY.value).whenHeld(armSetpoint1);
 
-            Command upperArmPos = new InstantCommand(() -> ArmSubsystem.getInstance().setPosition(600));
-            new JoystickButton(driverStick, XboxController.Button.kB.value).whenHeld(upperArmPos);
+            InstantCommand armSetpoint2 = new InstantCommand(() -> ArmSubsystem.getInstance().setpoint(2));
+            new JoystickButton(driverStick, XboxController.Button.kB.value).whenHeld(armSetpoint2);
+
+            InstantCommand armSetpoint3 = new InstantCommand(() -> ArmSubsystem.getInstance().setpoint(3));
+            new JoystickButton(driverStick, XboxController.Button.kA.value).whenHeld(armSetpoint3);
         }
 
         sensitiveDriving = new SensitiveDriverControl(driverStick);

--- a/src/main/java/frc/robot/config/Config.java
+++ b/src/main/java/frc/robot/config/Config.java
@@ -183,11 +183,15 @@ public class Config {
     public static final boolean TELEOP_SQUARE_JOYSTICK_INPUTS = true;
     
     // PIDF values for the arm
-    public static double ARM_PID_P = robotSpecific(5);
+    public static double ARM_PID_P = 0;//robotSpecific(2); // 5   0.5115
     public static double ARM_PID_I = robotSpecific(0.0);
     public static double ARM_PID_D = robotSpecific(0.0);
-    public static double ARM_PID_F = robotSpecific(0.05);
+    public static double ARM_PID_F = 0;// robotSpecific(7); // 0.05  2.0
+    public static double ARM_PID_IZONE = robotSpecific(0.0);
 
+    public static int ARM_PID_CRUISE_VELOCITY = robotSpecific(150);
+    public static int ARM_PID_ACCELERATION = robotSpecific(60);
+    public static int ARM_PID_SCURVE = robotSpecific(2);
 
     // Define a global constants table for subsystems to use
     public static NetworkTable constantsTable = NetworkTableInstance.getDefault().getTable("constants");

--- a/src/main/java/frc/robot/config/Config.java
+++ b/src/main/java/frc/robot/config/Config.java
@@ -167,7 +167,7 @@ public class Config {
     
     public static boolean INVERT_ARM_TALON = robotSpecific(true, true, false);
     
-    public static int ARM_ALLOWABLE_CLOSED_LOOP_ERROR_TICKS = 4096;
+    public static int ARM_ALLOWABLE_CLOSED_LOOP_ERROR_TICKS = 0;
     
     // Timeouts for sending CAN bus commands
     public static final int CAN_TIMEOUT_SHORT = 10;
@@ -185,13 +185,16 @@ public class Config {
     // PIDF values for the arm
     public static double ARM_PID_P = 0;//robotSpecific(2); // 5   0.5115
     public static double ARM_PID_I = robotSpecific(0.0);
-    public static double ARM_PID_D = robotSpecific(0.0);
-    public static double ARM_PID_F = 0;// robotSpecific(7); // 0.05  2.0
+    public static double ARM_PID_D = robotSpecific(0);
+    public static double ARM_PID_F = 0;// 4;//robotSpecific(6); // 0.05  2.0  7
     public static double ARM_PID_IZONE = robotSpecific(0.0);
 
-    public static int ARM_PID_CRUISE_VELOCITY = robotSpecific(150);
-    public static int ARM_PID_ACCELERATION = robotSpecific(60);
+    public static int ARM_PID_CRUISE_VELOCITY = robotSpecific(20);
+    public static int ARM_PID_ACCELERATION = robotSpecific(10);
     public static int ARM_PID_SCURVE = robotSpecific(2);
+
+    public static double ARM_PERCENT_AT_HORIZONTAL = robotSpecific(0.0, 0.13);//0.22/1.5);
+    public static double ARM_COS_VERT_STRETCH = robotSpecific(0.0, 1.0);//0.6);
 
     // Define a global constants table for subsystems to use
     public static NetworkTable constantsTable = NetworkTableInstance.getDefault().getTable("constants");

--- a/src/main/java/frc/robot/config/Config.java
+++ b/src/main/java/frc/robot/config/Config.java
@@ -167,6 +167,7 @@ public class Config {
     
     public static boolean INVERT_ARM_TALON = robotSpecific(true, true, false);
     
+
     public static int ARM_ALLOWABLE_CLOSED_LOOP_ERROR_TICKS = 0;
     
     // Timeouts for sending CAN bus commands
@@ -183,15 +184,15 @@ public class Config {
     public static final boolean TELEOP_SQUARE_JOYSTICK_INPUTS = true;
     
     // PIDF values for the arm
-    public static double ARM_PID_P = 0;//robotSpecific(2); // 5   0.5115
-    public static double ARM_PID_I = robotSpecific(0.0);
-    public static double ARM_PID_D = robotSpecific(0);
-    public static double ARM_PID_F = 0;// 4;//robotSpecific(6); // 0.05  2.0  7
-    public static double ARM_PID_IZONE = robotSpecific(0.0);
+    public static double ARM_PID_P = 9.5;//robotSpecific(2); // 5   0.5115
+    public static double ARM_PID_I = 0.015;
+    public static double ARM_PID_D = 1.0;
+    public static double ARM_PID_F = 2.5;//robotSpecific(6); // 0.05  2.0  7
+    public static double ARM_PID_IZONE = 20;
 
-    public static int ARM_PID_CRUISE_VELOCITY = robotSpecific(20);
-    public static int ARM_PID_ACCELERATION = robotSpecific(10);
-    public static int ARM_PID_SCURVE = robotSpecific(2);
+    public static int ARM_PID_CRUISE_VELOCITY = robotSpecific(50); //30
+    public static int ARM_PID_ACCELERATION = robotSpecific(17); //15
+    public static int ARM_PID_SCURVE = robotSpecific(5);
 
     public static double ARM_PERCENT_AT_HORIZONTAL = robotSpecific(0.0, 0.13);//0.22/1.5);
     public static double ARM_COS_VERT_STRETCH = robotSpecific(0.0, 1.0);//0.6);

--- a/src/main/java/frc/robot/subsystems/ArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ArmSubsystem.java
@@ -2,7 +2,10 @@ package frc.robot.subsystems;
 
 import com.ctre.phoenix.ErrorCode;
 import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.DemandType;
 import com.ctre.phoenix.motorcontrol.FeedbackDevice;
+import com.ctre.phoenix.motorcontrol.LimitSwitchNormal;
+import com.ctre.phoenix.motorcontrol.LimitSwitchSource;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.StatusFrame;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
@@ -14,8 +17,16 @@ import frc.robot.config.Config;
 public class ArmSubsystem extends ConditionalSubsystemBase {
 
     // TODO Change placeholder values to actual limits
-    private static final int FORWARD_LIMIT_TICKS = Config.robotSpecific(4150, 2200);
-    private static final int REVERSE_LIMIT_TICKS = Config.robotSpecific(3500, 1300);
+    private static final int FORWARD_LIMIT_TICKS = Config.robotSpecific(4150, 900); //2200
+    private static final int REVERSE_LIMIT_TICKS = Config.robotSpecific(3500, 0); // 1300  
+
+    // Percent output needed to hold the arm at horizontal
+    private static final double PERCENT_AT_HORIZONTAL = Config.robotSpecific(0.0, 0.02);
+    // private static final int EXTRA_POWER_RANGE_TICK = REVERSE_LIMIT_TICKS + 300;
+    // private static final double EXTRa_POWER_PERCENT = 0.2;
+
+    // Tick count of the arm at horizontal. In this case the lower limit is horizontal
+    private static final int ARM_HORIZONTAL_TICKS = REVERSE_LIMIT_TICKS;
 
     private static final int acceptableError = 50;
 
@@ -50,6 +61,8 @@ public class ArmSubsystem extends ConditionalSubsystemBase {
                 0, Config.CAN_TIMEOUT_SHORT);
 
         SmartDashboard.putNumber("Arm Error Code", errorCode.value);
+        System.out.println("Arm error code : " + errorCode.name());
+        System.out.println("Arm Encoder: " + armTalon.getSelectedSensorPosition(0));
 
         armTalon.setInverted(Config.INVERT_ARM_TALON);
 
@@ -66,13 +79,19 @@ public class ArmSubsystem extends ConditionalSubsystemBase {
         armTalon.config_kI(0, Config.ARM_PID_I, Config.CAN_TIMEOUT_SHORT);
         armTalon.config_kD(0, Config.ARM_PID_D, Config.CAN_TIMEOUT_SHORT);
         armTalon.config_kF(0, Config.ARM_PID_F, Config.CAN_TIMEOUT_SHORT);
+        armTalon.config_IntegralZone(0, Config.ARM_PID_IZONE, Config.CAN_TIMEOUT_SHORT);
+
+        armTalon.configMotionCruiseVelocity(Config.ARM_PID_CRUISE_VELOCITY, Config.CAN_TIMEOUT_SHORT);
+        armTalon.configMotionAcceleration(Config.ARM_PID_ACCELERATION, Config.CAN_TIMEOUT_SHORT);
+        armTalon.configMotionSCurveStrength(Config.ARM_PID_SCURVE, Config.CAN_TIMEOUT_SHORT);
+     
 
 
         // Set up the close loop period
         armTalon.configClosedLoopPeriod(0, Config.CAN_TIMEOUT_LONG);
         armTalon.setSensorPhase(Config.ARM_PHASE);
-        armTalon.setStatusFramePeriod(StatusFrame.Status_12_Feedback1, 20, Config.CAN_TIMEOUT_LONG);
-        armTalon.setStatusFramePeriod(StatusFrame.Status_13_Base_PIDF0, 20, Config.CAN_TIMEOUT_LONG);
+        // armTalon.setStatusFramePeriod(StatusFrame.Status_12_Feedback1, 20, Config.CAN_TIMEOUT_LONG);
+        // armTalon.setStatusFramePeriod(StatusFrame.Status_13_Base_PIDF0, 20, Config.CAN_TIMEOUT_LONG);
 
         //    Enable forward soft limit and set the value in encoder ticks
         armTalon.configForwardSoftLimitEnable(true);
@@ -81,6 +100,10 @@ public class ArmSubsystem extends ConditionalSubsystemBase {
         armTalon.configReverseSoftLimitEnable(true);
         armTalon.configReverseSoftLimitThreshold(REVERSE_LIMIT_TICKS, Config.CAN_TIMEOUT_SHORT);
         
+        // Limit switch 
+        armTalon.configReverseLimitSwitchSource(LimitSwitchSource.FeedbackConnector, LimitSwitchNormal.NormallyOpen, Config.CAN_TIMEOUT_SHORT);
+        armTalon.configClearPositionOnLimitR(true, Config.CAN_TIMEOUT_SHORT);
+
         // Max voltage to apply with the talon. 12 is the maximum
         armTalon.configVoltageCompSaturation(12, Config.CAN_TIMEOUT_LONG);
         armTalon.enableVoltageCompensation(true);
@@ -95,7 +118,9 @@ public class ArmSubsystem extends ConditionalSubsystemBase {
 
         if (errorCode.value == 0) {
             talonErrorCondition.setState(true);
-        }
+        } 
+
+        armTalon.setSelectedSensorPosition(0);
     }
 
     public void addToCurrentPosition(int increment) {
@@ -142,22 +167,31 @@ public class ArmSubsystem extends ConditionalSubsystemBase {
     
     @Override
     public void periodic() {
-        super.periodic();
+        // super.periodic();
+
+        double currentTicks = armTalon.getSelectedSensorPosition(0);
 
         SmartDashboard.putNumber("Lower Limit", REVERSE_LIMIT_TICKS);
         SmartDashboard.putNumber("Upper Limit", FORWARD_LIMIT_TICKS);
-        if (Config.ARM_TALON != -1)
-            SmartDashboard.putNumber("Arm Motor Ticks", armTalon.getSelectedSensorPosition());
-        //GABBY commented out
-        //SmartDashboard.putNumber("Arm Angle", toDeg(armTalon.getSelectedSensorPosition()));
+        // if (Config.ARM_TALON != -1)
+            SmartDashboard.putNumber("Arm Motor Ticks", currentTicks);
+        SmartDashboard.putNumber("Arm Angle", toDeg(currentTicks));
         SmartDashboard.putNumber("Desired Position", currentPosition);
 
+        
+        // Set the desired position every cycle and update the gravity compensation at the current angle.
+        double currentAngleFromHorizontal = toDeg(currentTicks - ARM_HORIZONTAL_TICKS);
+        double gravityCompensation = PERCENT_AT_HORIZONTAL * Math.cos(Math.toRadians(currentAngleFromHorizontal));
+        armTalon.set(ControlMode.MotionMagic, currentPosition, DemandType.ArbitraryFeedForward, gravityCompensation);
 
-        armTalon.set(ControlMode.Position, currentPosition);
+        SmartDashboard.putNumber("Arm Gravity Compensation", gravityCompensation);
+        SmartDashboard.putBoolean("Arm Limit Switch", armTalon.getSensorCollection().isRevLimitSwitchClosed());
+
+        // If near lower limit, stop the motor.
         if (Config.ARM_TALON != 1) {
-            if(armTalon.getSelectedSensorPosition() <= REVERSE_LIMIT_TICKS + 25) {
-                armTalon.set(0.0);
-            }
+            // if(currentTicks <= REVERSE_LIMIT_TICKS + 25) {
+            //     armTalon.set(0.0);
+            // }
         }
     }
 
@@ -169,11 +203,15 @@ public class ArmSubsystem extends ConditionalSubsystemBase {
         return Math.abs(armTalon.getSelectedSensorPosition() - position) < acceptableError; 
     }
 
+    public void setPosition(int ticks) {
+        currentPosition = ticks;
+    }
+
     /**
      * @param units CTRE mag encoder sensor units
      * @return degrees rounded to tenths.
      */
-    Double toDeg(int units) {
+    Double toDeg(double units) {
         double deg = units * 360.0 / 4096.0;
 
         /* truncate to 0.1 res */

--- a/src/main/java/frc/robot/subsystems/ArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ArmSubsystem.java
@@ -116,6 +116,9 @@ public class ArmSubsystem extends ConditionalSubsystemBase {
             talonErrorCondition.setState(true);
         }
 
+        if (Config.robotId != 0) {
+            armTalon.setSelectedSensorPosition(0);
+        }
         currentPosition = (int) armTalon.getSelectedSensorPosition();
     }
 


### PR DESCRIPTION
Reworked a bit of the arm subsystem. All changes were only to use talon features or remove talon settings so I could be sure I knew exactly what it was going to do. 

Added an equation made by Steve d&f mentor to compensate gravity and the spring making the control loop more accurate at each position as supposed to being more accurate at only certain positions.

Changed from a position loop to motion magic. Now accelerates to a given value and decelerates to the target position.

Added functionality to handle the limit switch which will reset the encoder value to 0 when pressed and stop the motor from continuing to push the intake into itself when it reaches the bottom.

HUGE NOTICE: This change of resetting the encoder to 0 when it hits the limit switch, changes the values of the setpoints. Before the first time the limit switch was hit, the encoder values were way higher than they should be since the previous code used them there. This would result in the arm trying to drive to a position past mechanical stops. At the time of writing this, the prac bot hasn't hit the limit switch (which I don't even think is wired) which would result in the arms trying to drive. 

TDLR OF NOTICE -> There is temporary code on lines 119-121 to set the encoder value to 0 on any robot other than the comp bot when booted up. As soon as the limit switch on pracbot is (wired if needed) and pressed, remove these lines.
